### PR TITLE
Pom fixes + cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,11 +141,6 @@
             <version>1.2.4</version>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-java</artifactId>
-            <version>1.1.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <version>3.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
     </description>
     <url>https://github.com/HPSoftware/octane-cucumber-jvm</url>
 
+    <properties>
+        <cucumber.version>1.2.4</cucumber.version>
+    </properties>
+
     <licenses>
         <license>
             <name>MIT License</name>
@@ -132,28 +136,22 @@
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
-            <artifactId>gherkin</artifactId>
-            <version>2.12.2</version>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
         </dependency>
-        <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-core</artifactId>
-            <version>1.2.4</version>
-        </dependency>
+
+        <!--test dependencies follow-->
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <version>3.4</version>
-        </dependency>
-        <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-junit</artifactId>
-            <version>1.2.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>1.2.4</version>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Fix pom: rm wrong duplicate cucumber-java (1.1.5)
- fix scope: easymock and cucumber-java are only used by tests => scope=test
- refactoring: no need to declare cucumber-core, gherkin as deps: implicitly brought in by cucumber-junit
- refactoring: extract the version of cucumber to a pom property
