### PR TITLE
Fix issue #6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.hpe.alm.octane</groupId>
     <artifactId>octane-cucumber-jvm</artifactId>
-    <version>12.53.22</version>
+    <version>12.53.23-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>octane-cucumber-jvm</name>

--- a/src/main/java/com/hpe/alm/octane/infra/StepElement.java
+++ b/src/main/java/com/hpe/alm/octane/infra/StepElement.java
@@ -1,5 +1,6 @@
 package com.hpe.alm.octane.infra;
 
+import gherkin.formatter.model.Result;
 import gherkin.formatter.model.Step;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -38,9 +39,7 @@ public class StepElement implements GherkinSerializer {
         Element step = doc.createElement(STEP_TAG_NAME);
 
         step.setAttribute("name", _name);
-        if (_status != null && !_status.isEmpty()) {
-            step.setAttribute("status", _status);
-        }
+        step.setAttribute("status", _status != null && !_status.isEmpty() ? _status : Result.UNDEFINED.getStatus());
 
         String duration = _duration != null ? _duration.toString() : "0";
         step.setAttribute("duration", duration);


### PR DESCRIPTION
This fix arbitrarily sets the status to "undefined" in case the StepElement's status had not been set, which happens for example when the step is NOT implemented, aka is pending.

Needs testing.

Could be improved. For example, when a step fails all of the following steps should be marked as skipped, *regardless of whether the step is pending or not*.
So for example:
- given the scenario "Given A, When B, Then C"
- and C is not implemented
- when A fails
- then both B and C should be marked as "skipped" (IMHO)